### PR TITLE
Constraint CH052178 Jauchegrube_Mistlege gelöscht

### DIFF
--- a/models/DMAV_V1_0_Validierung.ili
+++ b/models/DMAV_V1_0_Validierung.ili
@@ -672,14 +672,6 @@ IMPORTS DMAV_Gebaeudeadressen_V1_0;
             MANDATORY CONSTRAINT CH052178: (
                 (Einzelobjektart == #uebriger_Gebaeudeteil) => (objectCount(Punktelement) == 0)
             );
-			
-		    !!@ ilivalid.msg="Bei Art=Jauchengrube_Mistlege darf die Geometrie nicht in Punktelement sein";
-            !!@ ilivalid.msg_de="Bei Art=Jauchengrube_Mistlege darf die Geometrie nicht in Punktelement sein";
-            !!@ ilivalid.msg_fr="Pour les objets du Genre=fosse_purin_tas_fumier, la géométrie ne peut pas être définie dans la table Element_ponctuel";
-            !!@ ilivalid.msg_it="Per il genere Pozzo nero la geometria non deve essere del tipo puntiforme";
-            MANDATORY CONSTRAINT CH052178: (
-                (Einzelobjektart == #Jauchengrube_Mistlege) => (objectCount(Punktelement) == 0)
-            );
 
             !!@ ilivalid.msg="EGID existiert nicht im GWR";
             !!@ ilivalid.msg_de="EGID existiert nicht im GWR";


### PR DESCRIPTION
Ich finde den CH052178 für Jauchegrube_Mistlege in https://github.com/geostandards-ch/DMAV-Validierungsmodell/blob/main/rules/DMAVTYM_Alles_V1_0.xlsx nicht. Oder weiss jemand von euch, wie der da reingekommen ist? Dann bitte Pull Request ablehnen.